### PR TITLE
Add missing semicolon in ara-classes-PlaypenSans.fea

### DIFF
--- a/sources/features/ara-classes-PlaypenSans.fea
+++ b/sources/features/ara-classes-PlaypenSans.fea
@@ -38,4 +38,4 @@
 
 @ALL_ara_ALL = [@dflt_ara_ALL @alt1_ara_ALL @alt2_ara_ALL @alt3_ara_ALL @no_ara_ALTS dottedCircle];
 
-@comb_marks_ara = [tahabove-ar wasla-ar gafsarkashabove-ar alefabove-ar alefbelow-ar hamzaabove-ar hamzabelow-ar hamzaaboveDamma-ar hamzaaboveDammatan-ar hamzaaboveFatha-ar hamzaaboveFathatan-ar hamzaaboveSukun-ar hamzabelowKasra-ar hamzabelowKasratan-ar fathatan-ar dammatan-ar kasratan-ar fatha-ar damma-ar kasra-ar shadda-ar shaddaFathatan-ar shaddaDammatan-ar shaddaKasratan-ar shaddaFatha-ar shaddaDamma-ar shaddaKasra-ar shaddaAlefabove-ar sukun-ar madda-ar noonghunnaabove-ar threedotsabove-ar goalcomma-ar]
+@comb_marks_ara = [tahabove-ar wasla-ar gafsarkashabove-ar alefabove-ar alefbelow-ar hamzaabove-ar hamzabelow-ar hamzaaboveDamma-ar hamzaaboveDammatan-ar hamzaaboveFatha-ar hamzaaboveFathatan-ar hamzaaboveSukun-ar hamzabelowKasra-ar hamzabelowKasratan-ar fathatan-ar dammatan-ar kasratan-ar fatha-ar damma-ar kasra-ar shadda-ar shaddaFathatan-ar shaddaDammatan-ar shaddaKasratan-ar shaddaFatha-ar shaddaDamma-ar shaddaKasra-ar shaddaAlefabove-ar sukun-ar madda-ar noonghunnaabove-ar threedotsabove-ar goalcomma-ar];


### PR DESCRIPTION
Looking into issues with compiling the FEA for this project; it is the first time I have encountered FEA `include` statements inside `feature` blocks.

After getting that working I ran into this: the last statement in this file is missing a semicolon. I'm not sure why fonttools is accepting this, but it might be something silly like that the semicolon after the `include` statement is intact after the concatenation? In any case the spec is clear that there should be a semicolon here.


This is part of Google Fonts work on a new compiler, see https://github.com/googlefonts/fontc for more background :)